### PR TITLE
Fix: Allow same attribute name for different applications in schema

### DIFF
--- a/internal/profile_schema/service/profile_schema_service.go
+++ b/internal/profile_schema/service/profile_schema_service.go
@@ -84,13 +84,28 @@ func (s *ProfileSchemaService) AddProfileSchemaAttributesForScope(schemaAttribut
 			return err
 		}
 		if existing != nil {
-			errorMsg := fmt.Sprintf("Attribute '%s' already exists for org '%s'", attr.AttributeName, attr.OrgId)
-			clientError := errors2.NewClientError(errors2.ErrorMessage{
-				Code:        errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Code,
-				Message:     errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Message,
-				Description: errorMsg,
-			}, http.StatusConflict)
-			return clientError
+			// For application_data attributes, check both attribute name AND application identifier
+			if scope == constants.ApplicationData {
+				if existing.ApplicationIdentifier == attr.ApplicationIdentifier {
+					errorMsg := fmt.Sprintf("Attribute '%s' already exists for application '%s' in org '%s'", 
+						attr.AttributeName, attr.ApplicationIdentifier, attr.OrgId)
+					clientError := errors2.NewClientError(errors2.ErrorMessage{
+						Code:        errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Code,
+						Message:     errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Message,
+						Description: errorMsg,
+					}, http.StatusConflict)
+					return clientError
+				}
+			} else {
+				// For non-application attributes, duplicate names are not allowed
+				errorMsg := fmt.Sprintf("Attribute '%s' already exists for org '%s'", attr.AttributeName, attr.OrgId)
+				clientError := errors2.NewClientError(errors2.ErrorMessage{
+					Code:        errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Code,
+					Message:     errors2.SCHEMA_ATTRIBUTE_ALREADY_EXISTS.Message,
+					Description: errorMsg,
+				}, http.StatusConflict)
+				return clientError
+			}
 		}
 	}
 

--- a/test/integration/profile_schema_test.go
+++ b/test/integration/profile_schema_test.go
@@ -38,7 +38,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				createAttr(SuperTenantOrg, "identity_attributes.email", constants.StringDataType, "combine", constants.MutabilityReadWrite),
 				createAttr(SuperTenantOrg, "identity_attributes.phone", constants.StringDataType, "combine", constants.MutabilityReadWrite),
 			}
-			err := svc.AddProfileSchemaAttributesForScope(identityAttrs, constants.IdentityAttributes)
+			err := svc.AddProfileSchemaAttributesForScope(identityAttrs, constants.IdentityAttributes, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add identity attributes")
 
 			// 2. Traits
@@ -53,7 +53,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 					MultiValued:   true,
 				},
 			}
-			err = svc.AddProfileSchemaAttributesForScope(traits, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope(traits, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add traits attributes")
 
 			// 3. Application Data
@@ -69,44 +69,128 @@ func Test_ProfileSchemaService(t *testing.T) {
 					ApplicationIdentifier: "app_1",
 				},
 			}
-			err = svc.AddProfileSchemaAttributesForScope(appData, constants.ApplicationData)
+			err = svc.AddProfileSchemaAttributesForScope(appData, constants.ApplicationData, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add application_data attributes")
 
-			_ = svc.DeleteProfileSchema(SuperTenantOrg)
+			_ = svc.DeleteProfileSchema(SuperTenantOrg)	
 			_ = svc.DeleteProfileSchemaAttributesByScope(SuperTenantOrg, constants.IdentityAttributes)
 		})
 
 		t.Run("Add_InvalidScope_ShouldFail", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "invalidscope.email", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, "invalidscope")
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, "invalidscope", SuperTenantOrg)
 			errDesc := utils.ExtractErrorDescription(err)
 			require.Contains(t, errDesc, "Invalid scope", "Expected validation failure for invalid scope")
 		})
 
 		t.Run("Add_ConflictingScope_ShouldFail", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "identity_attributes.email", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, "invalidscope")
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, "invalidscope", SuperTenantOrg)
 			errDesc := utils.ExtractErrorDescription(err)
 			require.Contains(t, errDesc, "does not match the scope", "Expected validation failure for invalid scope")
 		})
 
 		t.Run("Add_MissingAppIdentifier_ShouldFail", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "application_data.email", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.ApplicationData)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.ApplicationData, SuperTenantOrg)
 			errDesc := utils.ExtractErrorDescription(err)
 			require.Contains(t, errDesc, "Application identifier is required", "Expected validation failure for missing application identifier")
 		})
 
+		t.Run("Add_SameAttributeNameDifferentApps_ShouldSucceed", func(t *testing.T) {
+			// Test that the same attribute name can be used for different applications
+			app1Attr := model.ProfileSchemaAttribute{
+				OrgId:                 SuperTenantOrg,
+				AttributeId:           uuid.New().String(),
+				AttributeName:         "application_data.theme",
+				ValueType:             constants.StringDataType,
+				MergeStrategy:         "overwrite",
+				Mutability:            constants.MutabilityReadWrite,
+				ApplicationIdentifier: "mobile-app",
+			}
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{app1Attr}, constants.ApplicationData, SuperTenantOrg)
+			require.NoError(t, err, "Failed to add theme attribute for mobile-app")
+
+			// Add the SAME attribute name for a DIFFERENT application - should succeed
+			app2Attr := model.ProfileSchemaAttribute{
+				OrgId:                 SuperTenantOrg,
+				AttributeId:           uuid.New().String(),
+				AttributeName:         "application_data.theme",
+				ValueType:             constants.StringDataType,
+				MergeStrategy:         "overwrite",
+				Mutability:            constants.MutabilityReadWrite,
+				ApplicationIdentifier: "web-app",
+			}
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{app2Attr}, constants.ApplicationData, SuperTenantOrg)
+			require.NoError(t, err, "Should allow same attribute name for different applications")
+
+			// Verify both attributes exist
+			schema, err := svc.GetProfileSchema(SuperTenantOrg)
+			require.NoError(t, err)
+			appDataSchemaMap := schema[constants.ApplicationData].(map[string][]model.ProfileSchemaAttribute)
+			
+			mobileThemeFound := false
+			webThemeFound := false
+			for _, attrs := range appDataSchemaMap {
+				for _, attr := range attrs {
+					if attr.AttributeName == "application_data.theme" {
+						if attr.ApplicationIdentifier == "mobile-app" {
+							mobileThemeFound = true
+						}
+						if attr.ApplicationIdentifier == "web-app" {
+							webThemeFound = true
+						}
+					}
+				}
+			}
+			require.True(t, mobileThemeFound, "mobile-app theme attribute not found")
+			require.True(t, webThemeFound, "web-app theme attribute not found")
+
+			_ = svc.DeleteProfileSchema(SuperTenantOrg)
+		})
+
+		t.Run("Add_SameAttributeNameSameApp_ShouldFail", func(t *testing.T) {
+			// Test that duplicate attribute for the SAME application is blocked
+			app1Attr := model.ProfileSchemaAttribute{
+				OrgId:                 SuperTenantOrg,
+				AttributeId:           uuid.New().String(),
+				AttributeName:         "application_data.language",
+				ValueType:             constants.StringDataType,
+				MergeStrategy:         "overwrite",
+				Mutability:            constants.MutabilityReadWrite,
+				ApplicationIdentifier: "mobile-app",
+			}
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{app1Attr}, constants.ApplicationData, SuperTenantOrg)
+			require.NoError(t, err, "Failed to add language attribute for mobile-app")
+
+			// Try to add the SAME attribute for the SAME application - should fail
+			duplicateAttr := model.ProfileSchemaAttribute{
+				OrgId:                 SuperTenantOrg,
+				AttributeId:           uuid.New().String(),
+				AttributeName:         "application_data.language",
+				ValueType:             constants.StringDataType,
+				MergeStrategy:         "overwrite",
+				Mutability:            constants.MutabilityReadWrite,
+				ApplicationIdentifier: "mobile-app",
+			}
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{duplicateAttr}, constants.ApplicationData, SuperTenantOrg)
+			require.Error(t, err, "Should not allow duplicate attribute for same application")
+			errDesc := utils.ExtractErrorDescription(err)
+			require.Contains(t, errDesc, "already exists for application", "Expected error message about duplicate attribute")
+
+			_ = svc.DeleteProfileSchema(SuperTenantOrg)
+		})
+
 		t.Run("Add_TooDeepAttribute_ShouldFail", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "traits.orders.payment.card.type.extra", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits, SuperTenantOrg)
 			errDesc := utils.ExtractErrorDescription(err)
 			require.Contains(t, errDesc, "Attribute exceeds the maximum depth of 4", "Expected validation failure for attribute depth > 4")
 		})
 
 		t.Run("Add_MaxDepthAttribute_ShouldSucceed", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "traits.orders.payment.card.type", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Expected success for depth 4 attribute")
 			_ = svc.DeleteProfileSchema(SuperTenantOrg)
 			_ = svc.DeleteProfileSchemaAttributesByScope(SuperTenantOrg, constants.IdentityAttributes)
@@ -115,7 +199,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 		t.Run("Add_ValidSubAttribute_ShouldSucceed", func(t *testing.T) {
 			// Create sub-attribute first
 			subAttr := createAttr(SuperTenantOrg, "traits.orders.payment", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{subAttr}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{subAttr}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err)
 
 			// Create parent with sub-attribute (valid: one level deeper)
@@ -134,7 +218,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				},
 			}
 
-			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{parent}, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{parent}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Expected success for valid sub-attribute relationship")
 			_ = svc.DeleteProfileSchema(SuperTenantOrg)
 			_ = svc.DeleteProfileSchemaAttributesByScope(SuperTenantOrg, constants.IdentityAttributes)
@@ -150,7 +234,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				MergeStrategy: "combine",
 				Mutability:    constants.MutabilityReadWrite,
 			}
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{subAttr}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{subAttr}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Sub-attribute creation failed unexpectedly")
 
 			// Step 2: Parent referencing invalid deeper sub-attribute
@@ -169,7 +253,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				},
 			}
 
-			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{parent}, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{parent}, constants.Traits, SuperTenantOrg)
 			errDesc := utils.ExtractErrorDescription(err)
 			require.Contains(t, errDesc, "one level deeper", "Expected failure due to invalid sub-attribute depth")
 			_ = svc.DeleteProfileSchema(SuperTenantOrg)
@@ -180,7 +264,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 			// 1️ Level 4 leaf
 			l4 := createAttr(SuperTenantOrg, "traits.orders.payment.card.type",
 				constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l4}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l4}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add level 4 attribute")
 
 			// 2️Level 3 parent (complex) → references level 4
@@ -195,7 +279,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 					{AttributeId: l4.AttributeId, AttributeName: l4.AttributeName},
 				},
 			}
-			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l3}, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l3}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add level 3 attribute")
 
 			// 3️ Level 2 parent → references level 3
@@ -210,7 +294,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 					{AttributeId: l3.AttributeId, AttributeName: l3.AttributeName},
 				},
 			}
-			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l2}, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l2}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add level 2 attribute")
 
 			// 4️Level 1 parent → references level 2
@@ -225,7 +309,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 					{AttributeId: l2.AttributeId, AttributeName: l2.AttributeName},
 				},
 			}
-			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l1}, constants.Traits)
+			err = svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{l1}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err, "Failed to add top-level parent attribute")
 
 			//  Everything should pass, proving depth=4 hierarchy works correctly
@@ -240,7 +324,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 			createAttr(SuperTenantOrg, "identity_attributes.email", constants.StringDataType, "combine", constants.MutabilityReadWrite),
 			createAttr(SuperTenantOrg, "identity_attributes.phone", constants.StringDataType, "combine", constants.MutabilityReadWrite),
 		}
-		_ = svc.AddProfileSchemaAttributesForScope(identityAttrs, constants.IdentityAttributes)
+		_ = svc.AddProfileSchemaAttributesForScope(identityAttrs, constants.IdentityAttributes, SuperTenantOrg)
 
 		// 2. Traits
 		traits := []model.ProfileSchemaAttribute{
@@ -254,7 +338,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				MultiValued:   true,
 			},
 		}
-		_ = svc.AddProfileSchemaAttributesForScope(traits, constants.Traits)
+		_ = svc.AddProfileSchemaAttributesForScope(traits, constants.Traits, SuperTenantOrg)
 
 		// 3. Application Data
 		appData := []model.ProfileSchemaAttribute{
@@ -269,7 +353,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 				ApplicationIdentifier: "app_1",
 			},
 		}
-		_ = svc.AddProfileSchemaAttributesForScope(appData, constants.ApplicationData)
+		_ = svc.AddProfileSchemaAttributesForScope(appData, constants.ApplicationData, SuperTenantOrg)
 
 		t.Run("Get_ProfileSchema_Success", func(t *testing.T) {
 			schema, err := svc.GetProfileSchema(SuperTenantOrg)
@@ -282,7 +366,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 
 		t.Run("Get_ById_ShouldReturnMatchingAttribute", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "identity_attributes.phone_number", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.IdentityAttributes)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.IdentityAttributes, SuperTenantOrg)
 			require.NoError(t, err)
 
 			fetched, err := svc.GetProfileSchemaAttributeById(SuperTenantOrg, attr.AttributeId)
@@ -305,7 +389,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "identity_attributes.temp_field", constants.StringDataType, "combine", constants.MutabilityReadWrite)
 			attr.AttributeId = attrId
 
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.IdentityAttributes)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.IdentityAttributes, SuperTenantOrg)
 			require.NoError(t, err)
 
 			updates := map[string]interface{}{
@@ -331,7 +415,7 @@ func Test_ProfileSchemaService(t *testing.T) {
 
 		t.Run("Delete_ProfileSchemaAttribute_ById", func(t *testing.T) {
 			attr := createAttr(SuperTenantOrg, "traits.to_delete", constants.StringDataType, "combine", constants.MutabilityReadWrite)
-			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits)
+			err := svc.AddProfileSchemaAttributesForScope([]model.ProfileSchemaAttribute{attr}, constants.Traits, SuperTenantOrg)
 			require.NoError(t, err)
 
 			err = svc.DeleteProfileSchemaAttributeById(SuperTenantOrg, attr.AttributeId)


### PR DESCRIPTION
## Purpose
> Fixes a bug where the system incorrectly blocked creating the same attribute name for different applications in the application_data scope. Additionally, ensures profile unification rules respect application boundaries by only matching application_data attributes within the same app_id, preventing incorrect cross-application profile merging.

## Goals
> Allow the same attribute name to be created for multiple applications
> Prevent duplicate attributes within the same application
> Ensure profile unification only matches application_data attributes when both the attribute value AND the app_id match
> Prevent cross-application profile merging

## Approach
> Modified AddProfileSchemaAttributesForScope() to check both attribute_name AND application_identifier for application_data scope attributes
> Added checkApplicationDataMatch() function to implement app-scoped attribute matching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Profile schema now allows identical attribute names to exist across different applications within the same organization.

* **Improvements**
  * Enhanced attribute validation with application-aware duplicate detection.
  * More specific error messages for attribute conflicts that include application identifiers.

* **Tests**
  * Expanded test coverage for organization-scoped attributes and cross-application attribute name reuse.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->