### PR TITLE
Parameterize key and cert in deployment.yml

### DIFF
--- a/install/helm/templates/cds-deployment.yaml
+++ b/install/helm/templates/cds-deployment.yaml
@@ -113,19 +113,16 @@ spec:
               subPath: deployment.yaml
               readOnly: true
             - name: cds-mtls-volume
-              mountPath: /app/repository/certs/client.cer
-              subPath: client.cer
+              mountPath: {{ .Values.cloud.deployment.cds.tls.cert_dir }}/{{ .Values.cloud.deployment.cds.tls.server_cert }}
+              subPath: {{ .Values.cloud.deployment.cds.tls.server_cert }}
               readOnly: true
             - name: cds-mtls-volume
-              mountPath: /app/repository/certs/customer-data-service-client-key.pem
-              subPath: customer-data-service-client-key.pem
+              mountPath: {{ .Values.cloud.deployment.cds.tls.cert_dir }}/{{ .Values.cloud.deployment.cds.tls.server_key }}
+              subPath: {{ .Values.cloud.deployment.cds.tls.server_key }}
             - name: cds-mtls-volume
-              mountPath: /app/repository/certs/{{ .Values.cloud.deployment.cds.tls.trust_store}}
+              mountPath: {{ .Values.cloud.deployment.cds.tls.cert_dir }}/{{ .Values.cloud.deployment.cds.tls.trust_store}}
               subPath: {{ .Values.cloud.deployment.cds.tls.trust_store}}
               readOnly: true
-            - name: is-public-cert
-              mountPath: /app/repository/certs/{{ .Values.cloud.deployment.cds.config.identityServer.certName }}
-              subPath: {{ .Values.cloud.deployment.cds.config.identityServer.certName }}
           envFrom:
             - secretRef:
                 name: cds-env-secret

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -59,9 +59,9 @@ cloud:
         mtls_enabled: false
         cert_dir : "/app/repository/certs"
         server_cert: "client.cer"
-        server_key: "customer-data-service-client-key.pem"
+        server_key: "client-key.pem"
         client_cert: "wso2carbontls.cer"
-        trust_store: "trust-store.pem"
+        trust_store: "truststore.pem"
 
       secrets:
         authServerClientId: "" # Add the auth server client ID


### PR DESCRIPTION
## Purpose
This pull request updates the Helm chart configuration for the Customer Data Service (CDS) deployment, focusing on how TLS certificate files are referenced and mounted. The changes improve flexibility by using configurable Helm values for certificate paths and filenames, and they update some default filenames to ensure consistency.

**Helm template improvements:**

* Updated the `cds-deployment.yaml` template to use Helm values (`.Values.cloud.deployment.cds.tls.cert_dir`, `.Values.cloud.deployment.cds.tls.server_cert`, `.Values.cloud.deployment.cds.tls.server_key`, `.Values.cloud.deployment.cds.tls.trust_store`) for mounting TLS certificates, making the deployment more configurable and less hardcoded.
* Removed the mounting of the `is-public-cert` volume, simplifying the volume mounts.

**Default value changes:**

* Changed the default `server_key` filename from `customer-data-service-client-key.pem` to `client-key.pem` in `values.yaml`.
* Changed the default `trust_store` filename from `trust-store.pem` to `truststore.pem` in `values.yaml`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated deployment configuration to use templated TLS certificate paths for improved environment flexibility
  * Standardized certificate file naming conventions in deployment settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->