### PR TITLE
Accept profile cookie via query param in InitProfile

### DIFF
--- a/internal/profile/handler/profile_handler.go
+++ b/internal/profile/handler/profile_handler.go
@@ -555,10 +555,15 @@ func (ph *ProfileHandler) InitProfile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if a valid cookie exists
-	profileCookie, err := r.Cookie(constants.ProfileCookie)
-	if err == nil && profileCookie.Value != "" {
-		if ph.handleExistingCookie(w, r, profileCookie.Value) {
+	// Check if a valid cookie exists (header cookie takes precedence, fall back to query param)
+	cookieVal := ""
+	if profileCookie, cErr := r.Cookie(constants.ProfileCookie); cErr == nil && profileCookie.Value != "" {
+		cookieVal = profileCookie.Value
+	} else if qv := r.URL.Query().Get(constants.ProfileCookie); qv != "" {
+		cookieVal = qv
+	}
+	if cookieVal != "" {
+		if ph.handleExistingCookie(w, r, cookieVal) {
 			return
 		}
 	}


### PR DESCRIPTION
## Purpose
Allow callers of `InitProfile` to pass the `cds_profile` cookie value as a URL query parameter when the HTTP cookie header is not available (e.g., server-to-server or non-browser clients), so existing temp profiles can still be resolved instead of always creating a new one.

## Related Issue
- N/A

## Implementation
- `internal/profile/handler/profile_handler.go`: in `InitProfile`, after reading `r.Cookie(constants.ProfileCookie)`, fall back to `r.URL.Query().Get(constants.ProfileCookie)` if the header cookie is missing or empty. The resolved value is fed into the existing `handleExistingCookie` path, so the downstream lookup (`GetProfileCookieById` → `IsActive` check → `GetProfile` → `setProfileCookie`) is unchanged.
- Header cookie continues to take precedence; the query-param branch only runs when no valid cookie header is present. All other cookie call sites and the sync paths remain untouched.