### PR TITLE
Use IS application UUID as the CDS application identifier

### DIFF
--- a/dbscripts/postgres.sql
+++ b/dbscripts/postgres.sql
@@ -82,6 +82,16 @@ CREATE TABLE application_data
     UNIQUE (profile_id, app_id)
 );
 
+CREATE TABLE applications
+(
+    app_id         VARCHAR(255) PRIMARY KEY,
+    org_handle     VARCHAR(255) NOT NULL,
+    client_id      VARCHAR(255),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (org_handle, client_id)
+);
+
 CREATE TABLE consent_categories
 (
     id                  SERIAL PRIMARY KEY,

--- a/docs/concepts/consent.md
+++ b/docs/concepts/consent.md
@@ -71,7 +71,7 @@ All attributes — `traits`, `identity_attributes`, and `application_data` — a
 
 A profile's `application_data` is a two-level map:
 
-```
+```text
 application_data
   └── <app_id>                 ← outer key: the app ID
         └── <data_group_key>   ← inner key: logical data category (e.g. "events", "saas_signups")

--- a/docs/concepts/consent.md
+++ b/docs/concepts/consent.md
@@ -65,7 +65,7 @@ All attributes — `traits`, `identity_attributes`, and `application_data` — a
 |---|---|
 | `identityAttributes` | Core identity fields (email, phone, name, etc.) |
 | `traits` | Behavioural and preference fields |
-| `applicationData` | Per-application data. `application_identifier` (the app's OAuth client ID) must match the schema's `application_identifier` |
+| `applicationData` | Per-application data. `application_identifier` (the app ID) must match the schema's `application_identifier` |
 
 ### applicationData attributes and application_identifier
 
@@ -73,14 +73,14 @@ A profile's `application_data` is a two-level map:
 
 ```
 application_data
-  └── <app_client_id>          ← outer key: the app's OAuth client ID
+  └── <app_id>                 ← outer key: the app ID
         └── <data_group_key>   ← inner key: logical data category (e.g. "events", "saas_signups")
               └── <value>
 ```
 
-When declaring consent attributes for application data, `application_identifier` is the **outer app client ID**. The attribute name encodes the inner data-group key: `application_data.<data_group>.<field>`.
+When declaring consent attributes for application data, `application_identifier` is the **outer app ID**. The attribute name encodes the inner data-group key: `application_data.<data_group>.<field>`.
 
-At filter time, consent is enforced by matching the **inner data-group key** against the consented attribute names — not the outer app client ID. This means if multiple apps write data under the same data-group key (e.g. `"events"`), they are all gated by the same consent entry.
+At filter time, consent is enforced by matching the **inner data-group key** against the consented attribute names — not the outer app ID. This means if multiple apps write data under the same data-group key (e.g. `"events"`), they are all gated by the same consent entry.
 
 ### Complex attributes
 

--- a/install/helm/confs/deployment.yaml
+++ b/install/helm/confs/deployment.yaml
@@ -19,6 +19,8 @@ addr:
 
 server_url: {{ .Values.cloud.deployment.cds.config.serverUrl | quote }}
 
+application_identifier_type: {{ .Values.cloud.deployment.cds.config.applicationIdentifierType | quote }}
+
 auth_server:
   host: {{ .Values.cloud.deployment.cds.config.identityServer.host }}
   port : {{ .Values.cloud.deployment.cds.config.identityServer.port }}

--- a/install/helm/values.yaml
+++ b/install/helm/values.yaml
@@ -51,6 +51,8 @@ cloud:
 
         serverUrl : "http://localhost:8900"
 
+        applicationIdentifierType: "client_id" # Application identifier mode: "client_id" (default) or "app_id"
+
         identityServer:
           host: localhost
           port: ""

--- a/internal/admin_config/service/admin_config_service.go
+++ b/internal/admin_config/service/admin_config_service.go
@@ -19,10 +19,16 @@
 package service
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/wso2/identity-customer-data-service/internal/admin_config/model"
 	"github.com/wso2/identity-customer-data-service/internal/admin_config/store"
+	appProvider "github.com/wso2/identity-customer-data-service/internal/application/provider"
 	consentService "github.com/wso2/identity-customer-data-service/internal/consent/service"
 	"github.com/wso2/identity-customer-data-service/internal/profile_schema/service"
+	sysconfig "github.com/wso2/identity-customer-data-service/internal/system/config"
+	"github.com/wso2/identity-customer-data-service/internal/system/errors"
 )
 
 // AdminConfigServiceInterface defines the service interface.
@@ -104,6 +110,24 @@ func (a AdminConfigService) UpdateAdminConfig(updatedConfig model.AdminConfig, o
 			return err
 		}
 		updatedConfig.InitialSchemaSyncDone = true
+	}
+
+	// In app_id mode, register each system application so its clientId->app_id mapping exists for the GET path.
+	if sysconfig.GetCDSRuntime().Config.UsesAppIDIdentifier() {
+		appService := appProvider.NewApplicationProvider().GetApplicationService()
+		for _, appID := range updatedConfig.SystemApplications {
+			exists, err := appService.ResolveAndRegisterApplication(appID, orgHandle)
+			if err != nil {
+				return err
+			}
+			if !exists {
+				return errors.NewClientError(errors.ErrorMessage{
+					Code:        errors.UPDATE_CONFIG_BAD_REQUEST.Code,
+					Message:     errors.UPDATE_CONFIG_BAD_REQUEST.Message,
+					Description: fmt.Sprintf("System application '%s' does not exist in the identity server.", appID),
+				}, http.StatusBadRequest)
+			}
+		}
 	}
 
 	return store.UpdateAdminConfig(updatedConfig, orgHandle)

--- a/internal/application/model/application.go
+++ b/internal/application/model/application.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package model
+
+// Application holds the information of an application.
+type Application struct {
+	AppID     string `json:"app_id"`
+	OrgHandle string `json:"org_handle"`
+	ClientID  string `json:"client_id"`
+}

--- a/internal/application/provider/application_provider.go
+++ b/internal/application/provider/application_provider.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package provider
+
+import (
+	"github.com/wso2/identity-customer-data-service/internal/application/service"
+)
+
+// ApplicationProviderInterface defines the interface for the application provider.
+type ApplicationProviderInterface interface {
+	GetApplicationService() service.ApplicationServiceInterface
+}
+
+// ApplicationProvider is the default implementation of the ApplicationProviderInterface.
+type ApplicationProvider struct{}
+
+// NewApplicationProvider creates a new instance of ApplicationProvider.
+func NewApplicationProvider() ApplicationProviderInterface {
+
+	return &ApplicationProvider{}
+}
+
+// GetApplicationService returns the application service instance.
+func (ap *ApplicationProvider) GetApplicationService() service.ApplicationServiceInterface {
+
+	return service.GetApplicationService()
+}

--- a/internal/application/service/application_service.go
+++ b/internal/application/service/application_service.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package service
+
+import (
+	"fmt"
+
+	"github.com/wso2/identity-customer-data-service/internal/application/model"
+	"github.com/wso2/identity-customer-data-service/internal/application/store"
+	"github.com/wso2/identity-customer-data-service/internal/system/client"
+	"github.com/wso2/identity-customer-data-service/internal/system/config"
+	"github.com/wso2/identity-customer-data-service/internal/system/log"
+)
+
+// ApplicationServiceInterface defines the interface for the application service.
+type ApplicationServiceInterface interface {
+	ResolveAndRegisterApplication(appIdentifier, orgHandle string) (bool, error)
+	ResolveAppIdentifierByClientID(orgHandle, clientID string) string
+}
+
+// ApplicationService is the default implementation of the ApplicationServiceInterface.
+type ApplicationService struct{}
+
+// GetApplicationService creates a new instance of ApplicationService.
+func GetApplicationService() ApplicationServiceInterface {
+
+	return &ApplicationService{}
+}
+
+// ResolveAndRegisterApplication validates the application in the identity server and persists its clientId.
+func (as *ApplicationService) ResolveAndRegisterApplication(appIdentifier, orgHandle string) (bool, error) {
+
+	logger := log.GetLogger()
+	cfg := config.GetCDSRuntime().Config
+	identityClient := client.NewIdentityClient(cfg)
+
+	app, exists, err := identityClient.GetApplication(appIdentifier, orgHandle)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		logger.Debug(fmt.Sprintf("Application '%s' does not exist in the identity server for organization '%s'",
+			appIdentifier, orgHandle))
+		return false, nil
+	}
+
+	// clientId is empty for SAML-only apps; the row is still persisted (with a NULL clientId) so the table
+	// holds an entry for every application.
+	if err := store.UpsertApplication(model.Application{
+		AppID:     appIdentifier,
+		OrgHandle: orgHandle,
+		ClientID:  app.ClientId,
+	}); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// ResolveAppIdentifierByClientID resolves an OAuth clientId to the app ID via the local store.
+func (as *ApplicationService) ResolveAppIdentifierByClientID(orgHandle, clientID string) string {
+
+	appIdentifier, err := store.GetAppIdentifierByClientID(orgHandle, clientID)
+	if err != nil {
+		log.GetLogger().Debug(fmt.Sprintf("Failed to resolve clientId for organization '%s'", orgHandle),
+			log.Error(err))
+		return ""
+	}
+	return appIdentifier
+}

--- a/internal/application/service/application_service.go
+++ b/internal/application/service/application_service.go
@@ -31,7 +31,7 @@ import (
 // ApplicationServiceInterface defines the interface for the application service.
 type ApplicationServiceInterface interface {
 	ResolveAndRegisterApplication(appIdentifier, orgHandle string) (bool, error)
-	ResolveAppIdentifierByClientID(orgHandle, clientID string) string
+	ResolveAppIdentifierByClientID(orgHandle, clientID string) (string, error)
 }
 
 // ApplicationService is the default implementation of the ApplicationServiceInterface.
@@ -72,14 +72,9 @@ func (as *ApplicationService) ResolveAndRegisterApplication(appIdentifier, orgHa
 	return true, nil
 }
 
-// ResolveAppIdentifierByClientID resolves an OAuth clientId to the app ID via the local store.
-func (as *ApplicationService) ResolveAppIdentifierByClientID(orgHandle, clientID string) string {
+// ResolveAppIdentifierByClientID resolves an OAuth clientId to the app ID via the local store. A missing mapping
+// returns an empty string with a nil error; a store failure is returned so callers can distinguish the two.
+func (as *ApplicationService) ResolveAppIdentifierByClientID(orgHandle, clientID string) (string, error) {
 
-	appIdentifier, err := store.GetAppIdentifierByClientID(orgHandle, clientID)
-	if err != nil {
-		log.GetLogger().Debug(fmt.Sprintf("Failed to resolve clientId for organization '%s'", orgHandle),
-			log.Error(err))
-		return ""
-	}
-	return appIdentifier
+	return store.GetAppIdentifierByClientID(orgHandle, clientID)
 }

--- a/internal/application/store/application_store.go
+++ b/internal/application/store/application_store.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package store
+
+import (
+	"fmt"
+
+	"github.com/wso2/identity-customer-data-service/internal/application/model"
+	"github.com/wso2/identity-customer-data-service/internal/system/database/provider"
+	"github.com/wso2/identity-customer-data-service/internal/system/database/scripts"
+	errors2 "github.com/wso2/identity-customer-data-service/internal/system/errors"
+	"github.com/wso2/identity-customer-data-service/internal/system/log"
+)
+
+// UpsertApplication persists the application information, refreshing the clientId on re-validation.
+func UpsertApplication(app model.Application) error {
+
+	logger := log.GetLogger()
+	dbClient, err := provider.NewDBProvider().GetDBClient()
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to get database client for persisting application: %s", app.AppID)
+		logger.Debug(errorMsg, log.Error(err))
+		return errors2.NewServerError(errors2.ErrorMessage{
+			Code:        errors2.UPSERT_APPLICATION_FAILED.Code,
+			Message:     errors2.UPSERT_APPLICATION_FAILED.Message,
+			Description: errorMsg,
+		}, err)
+	}
+	defer dbClient.Close()
+
+	// SAML-only apps have no clientId; store NULL so they don't collide on the (org_handle, client_id) unique key.
+	var clientID interface{}
+	if app.ClientID != "" {
+		clientID = app.ClientID
+	}
+
+	query := scripts.UpsertApplication[provider.NewDBProvider().GetDBType()]
+	_, err = dbClient.ExecuteQuery(query, app.AppID, app.OrgHandle, clientID)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Error occurred while persisting application: %s", app.AppID)
+		logger.Debug(errorMsg, log.Error(err))
+		return errors2.NewServerError(errors2.ErrorMessage{
+			Code:        errors2.UPSERT_APPLICATION_FAILED.Code,
+			Message:     errors2.UPSERT_APPLICATION_FAILED.Message,
+			Description: errorMsg,
+		}, err)
+	}
+
+	logger.Info(fmt.Sprintf("Application information persisted for app_id: %s", app.AppID))
+	return nil
+}
+
+// GetAppIdentifierByClientID resolves an OAuth clientId to the app ID.
+func GetAppIdentifierByClientID(orgHandle, clientID string) (string, error) {
+
+	logger := log.GetLogger()
+	dbClient, err := provider.NewDBProvider().GetDBClient()
+	if err != nil {
+		errorMsg := fmt.Sprintf("Failed to get database client for resolving clientId for organization: %s", orgHandle)
+		logger.Debug(errorMsg, log.Error(err))
+		return "", errors2.NewServerError(errors2.ErrorMessage{
+			Code:        errors2.GET_APPLICATION_FAILED.Code,
+			Message:     errors2.GET_APPLICATION_FAILED.Message,
+			Description: errorMsg,
+		}, err)
+	}
+	defer dbClient.Close()
+
+	query := scripts.GetAppIdentifierByClientID[provider.NewDBProvider().GetDBType()]
+	results, err := dbClient.ExecuteQuery(query, orgHandle, clientID)
+	if err != nil {
+		errorMsg := fmt.Sprintf("Error occurred while resolving clientId for organization: %s", orgHandle)
+		logger.Debug(errorMsg, log.Error(err))
+		return "", errors2.NewServerError(errors2.ErrorMessage{
+			Code:        errors2.GET_APPLICATION_FAILED.Code,
+			Message:     errors2.GET_APPLICATION_FAILED.Message,
+			Description: errorMsg,
+		}, err)
+	}
+
+	if len(results) == 0 {
+		return "", nil
+	}
+	appID, _ := results[0]["app_id"].(string)
+	return appID, nil
+}

--- a/internal/profile/handler/profile_handler.go
+++ b/internal/profile/handler/profile_handler.go
@@ -27,6 +27,7 @@ import (
 
 	adminConfigPkg "github.com/wso2/identity-customer-data-service/internal/admin_config/provider"
 	adminConfigService "github.com/wso2/identity-customer-data-service/internal/admin_config/service"
+	appProvider "github.com/wso2/identity-customer-data-service/internal/application/provider"
 	"github.com/wso2/identity-customer-data-service/internal/system/client"
 	"github.com/wso2/identity-customer-data-service/internal/system/config"
 	"github.com/wso2/identity-customer-data-service/internal/system/pagination"
@@ -94,12 +95,26 @@ func (ph *ProfileHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterParams := parseApplicationDataParams(r)
-	callerAppID := getCallerAppIDFromRequest(r)
-	isSystemApp := isCallerSystemApplication(orgHandle, callerAppID)
+	// The token identifies the caller by its OAuth clientId; the system-app check remains clientId-based.
+	callerClientID := getCallerClientIDFromRequest(r)
+	isSystemApp := isCallerSystemApplication(orgHandle, callerClientID)
+
+	// Application data is keyed by the caller's application identifier. In app_id mode the token's clientId is
+	// resolved to the app ID; in the legacy client_id mode the clientId is itself the key. System apps filter by
+	// the identifiers supplied in the request, so they need no resolution.
+	callerAppIdentifier := ""
+	if !isSystemApp && callerClientID != "" {
+		if config.GetCDSRuntime().Config.UsesAppIDIdentifier() {
+			callerAppIdentifier = appProvider.NewApplicationProvider().GetApplicationService().
+				ResolveAppIdentifierByClientID(orgHandle, callerClientID)
+		} else {
+			callerAppIdentifier = callerClientID
+		}
+	}
 
 	profile.ApplicationData = profileService.FilterApplicationData(
 		profile.ApplicationData,
-		callerAppID,
+		callerAppIdentifier,
 		isSystemApp,
 		filterParams,
 	)
@@ -1375,7 +1390,7 @@ func extractClaimKeyFromLocalURI(localURI string) string {
 	return parts[len(parts)-1]
 }
 
-func getCallerAppIDFromRequest(r *http.Request) string {
+func getCallerClientIDFromRequest(r *http.Request) string {
 	authHeader := r.Header.Get("Authorization")
 	if !strings.HasPrefix(authHeader, "Bearer ") {
 		return ""

--- a/internal/profile/handler/profile_handler.go
+++ b/internal/profile/handler/profile_handler.go
@@ -95,27 +95,19 @@ func (ph *ProfileHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	}
 
 	filterParams := parseApplicationDataParams(r)
-	// The token identifies the caller by its OAuth clientId; the system-app check remains clientId-based.
+	// In app_id mode the caller's clientId is resolved to its app ID; the system-app check runs on that identifier.
 	callerClientID := getCallerClientIDFromRequest(r)
-	isSystemApp := isCallerSystemApplication(orgHandle, callerClientID)
-
-	// Application data is keyed by the caller's application identifier. In app_id mode the token's clientId is
-	// resolved to the app ID; in the legacy client_id mode the clientId is itself the key. System apps filter by
-	// the identifiers supplied in the request, so they need no resolution.
-	callerAppIdentifier := ""
-	if !isSystemApp && callerClientID != "" {
-		if config.GetCDSRuntime().Config.UsesAppIDIdentifier() {
-			resolved, resolveErr := appProvider.NewApplicationProvider().GetApplicationService().
-				ResolveAppIdentifierByClientID(orgHandle, callerClientID)
-			if resolveErr != nil {
-				utils.HandleError(w, resolveErr)
-				return
-			}
-			callerAppIdentifier = resolved
-		} else {
-			callerAppIdentifier = callerClientID
+	callerAppIdentifier := callerClientID
+	if config.GetCDSRuntime().Config.UsesAppIDIdentifier() && callerClientID != "" {
+		resolved, resolveErr := appProvider.NewApplicationProvider().GetApplicationService().
+			ResolveAppIdentifierByClientID(orgHandle, callerClientID)
+		if resolveErr != nil {
+			utils.HandleError(w, resolveErr)
+			return
 		}
+		callerAppIdentifier = resolved
 	}
+	isSystemApp := isCallerSystemApplication(orgHandle, callerAppIdentifier)
 
 	profile.ApplicationData = profileService.FilterApplicationData(
 		profile.ApplicationData,

--- a/internal/profile/handler/profile_handler.go
+++ b/internal/profile/handler/profile_handler.go
@@ -105,8 +105,13 @@ func (ph *ProfileHandler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	callerAppIdentifier := ""
 	if !isSystemApp && callerClientID != "" {
 		if config.GetCDSRuntime().Config.UsesAppIDIdentifier() {
-			callerAppIdentifier = appProvider.NewApplicationProvider().GetApplicationService().
+			resolved, resolveErr := appProvider.NewApplicationProvider().GetApplicationService().
 				ResolveAppIdentifierByClientID(orgHandle, callerClientID)
+			if resolveErr != nil {
+				utils.HandleError(w, resolveErr)
+				return
+			}
+			callerAppIdentifier = resolved
 		} else {
 			callerAppIdentifier = callerClientID
 		}

--- a/internal/profile_schema/service/profile_schema_service.go
+++ b/internal/profile_schema/service/profile_schema_service.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 
+	appProvider "github.com/wso2/identity-customer-data-service/internal/application/provider"
 	"github.com/wso2/identity-customer-data-service/internal/profile_schema/model"
 	psstr "github.com/wso2/identity-customer-data-service/internal/profile_schema/store"
 	"github.com/wso2/identity-customer-data-service/internal/system/client"
@@ -299,11 +300,19 @@ func (s *ProfileSchemaService) validateSchemaAttribute(attr model.ProfileSchemaA
 
 var validateApplicationIdentifierFn = defaultValidateApplicationIdentifier
 
-func defaultValidateApplicationIdentifier(appID, orgHandle string) (error, bool) {
-	cfg := config.GetCDSRuntime().Config
-	identityClient := client.NewIdentityClient(cfg)
+// defaultValidateApplicationIdentifier validates the application identifier against the identity server.
+func defaultValidateApplicationIdentifier(appIdentifier, orgHandle string) (error, bool) {
+	if config.GetCDSRuntime().Config.UsesAppIDIdentifier() {
+		ok, err := appProvider.NewApplicationProvider().GetApplicationService().
+			ResolveAndRegisterApplication(appIdentifier, orgHandle)
+		if err != nil {
+			return err, false
+		}
+		return nil, ok
+	}
 
-	res, err := identityClient.FetchApplicationIdentifier(appID, orgHandle)
+	identityClient := client.NewIdentityClient(config.GetCDSRuntime().Config)
+	res, err := identityClient.FetchApplicationIdentifier(appIdentifier, orgHandle)
 	if err != nil {
 		return err, false
 	}

--- a/internal/system/client/identity_client.go
+++ b/internal/system/client/identity_client.go
@@ -342,6 +342,62 @@ func (c *IdentityClient) FetchApplicationIdentifier(applicationIdentifier, orgHa
 	return result, nil
 }
 
+// GetApplication fetches an application by ID. exists is false when it is not found.
+func (c *IdentityClient) GetApplication(appID, orgHandle string) (idpModel.ApplicationItem, bool, error) {
+
+	logger := log.GetLogger()
+	var app idpModel.ApplicationItem
+
+	token, err := c.FetchToken(orgHandle)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("Failed to get token for resolving application:%s of org:%s", appID, orgHandle),
+			log.Error(err))
+		return app, false, err
+	}
+
+	appsFailed := func(desc string, cause error) error {
+		return errors2.NewServerError(errors2.ErrorMessage{
+			Code:        errors2.GET_APPLICATIONS_FAILED.Code,
+			Message:     errors2.GET_APPLICATIONS_FAILED.Message,
+			Description: desc,
+		}, cause)
+	}
+
+	appEndpoint := fmt.Sprintf("https://%s/t/%s/api/server/v1/applications/%s", c.BaseURL, orgHandle, appID)
+	req, err := http.NewRequest("GET", appEndpoint, nil)
+	if err != nil {
+		return app, false, err
+	}
+	authCfg := config.GetCDSRuntime().Config.AuthServer
+	if authCfg.IsSystemAppGrantEnabled {
+		req.Header.Set("Authorization", constants.SystemAppHeader+constants.SpaceSeparator+token)
+	} else {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return app, false, appsFailed(fmt.Sprintf("Failed to fetch application:%s for org:%s", appID, orgHandle), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return app, false, nil
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		errorMsg := fmt.Sprintf("Applications endpoint returned status %d for app:%s org:%s. Response: %s",
+			resp.StatusCode, appID, orgHandle, strings.TrimSpace(string(body)))
+		return app, false, appsFailed(errorMsg, fmt.Errorf("applications endpoint non-200: %d", resp.StatusCode))
+	}
+
+	if err := json.Unmarshal(body, &app); err != nil {
+		return app, false, appsFailed(fmt.Sprintf("Failed to parse application response for app:%s org:%s",
+			appID, orgHandle), err)
+	}
+	return app, true, nil
+}
+
 // IntrospectToken introspects an opaque token using the introspection endpoint.
 func (c *IdentityClient) IntrospectToken(token, orgHandle string) (map[string]interface{}, error) {
 

--- a/internal/system/client/identity_client.go
+++ b/internal/system/client/identity_client.go
@@ -363,7 +363,8 @@ func (c *IdentityClient) GetApplication(appID, orgHandle string) (idpModel.Appli
 		}, cause)
 	}
 
-	appEndpoint := fmt.Sprintf("https://%s/t/%s/api/server/v1/applications/%s", c.BaseURL, orgHandle, appID)
+	appEndpoint := fmt.Sprintf("https://%s/t/%s/api/server/v1/applications/%s",
+		c.BaseURL, url.PathEscape(orgHandle), url.PathEscape(appID))
 	req, err := http.NewRequest("GET", appEndpoint, nil)
 	if err != nil {
 		return app, false, err
@@ -384,7 +385,11 @@ func (c *IdentityClient) GetApplication(appID, orgHandle string) (idpModel.Appli
 	if resp.StatusCode == http.StatusNotFound {
 		return app, false, nil
 	}
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return app, false, appsFailed(fmt.Sprintf("Failed to read application response for app:%s org:%s",
+			appID, orgHandle), err)
+	}
 	if resp.StatusCode != http.StatusOK {
 		errorMsg := fmt.Sprintf("Applications endpoint returned status %d for app:%s org:%s. Response: %s",
 			resp.StatusCode, appID, orgHandle, strings.TrimSpace(string(body)))

--- a/internal/system/config/config.go
+++ b/internal/system/config/config.go
@@ -91,6 +91,12 @@ type MessageQueueConfig struct {
 	Broker ExternalBrokerConfig `yaml:"broker"`
 }
 
+// Application identifier types.
+const (
+	ApplicationIdentifierTypeClientID = "client_id"
+	ApplicationIdentifierTypeAppID    = "app_id"
+)
+
 type Config struct {
 	Addr         AddrConfig         `yaml:"addr"`
 	ServerURL    string             `yaml:"server_url"`
@@ -101,6 +107,13 @@ type Config struct {
 	TLS          TLSConfig          `yaml:"tls"`
 	Cleanup      CleanupConfig      `yaml:"cleanup"`
 	MessageQueue MessageQueueConfig `yaml:"message_queue"`
+	// ApplicationIdentifierType selects how applications are identified: "client_id" (default) or "app_id".
+	ApplicationIdentifierType string `yaml:"application_identifier_type"`
+}
+
+// UsesAppIDIdentifier reports whether applications are identified by the app ID.
+func (c Config) UsesAppIDIdentifier() bool {
+	return c.ApplicationIdentifierType == ApplicationIdentifierTypeAppID
 }
 
 type TLSConfig struct {

--- a/internal/system/database/scripts/queries.go
+++ b/internal/system/database/scripts/queries.go
@@ -18,6 +18,22 @@
 
 package scripts
 
+// UpsertApplication inserts or updates the application information.
+var UpsertApplication = map[string]string{
+	"postgres": `INSERT INTO applications (app_id, org_handle, client_id, updated_at)
+		VALUES ($1, $2, $3, now())
+		ON CONFLICT (app_id) DO UPDATE SET
+			org_handle = EXCLUDED.org_handle,
+			client_id  = EXCLUDED.client_id,
+			updated_at = now()`,
+}
+
+// GetAppIdentifierByClientID resolves an OAuth clientId to the app_id.
+var GetAppIdentifierByClientID = map[string]string{
+	"postgres": `SELECT app_id FROM applications
+		WHERE org_handle = $1 AND client_id = $2 LIMIT 1`,
+}
+
 var DeleteProfileSchemaForOrg = map[string]string{
 	"postgres": `
         DELETE FROM profile_schema WHERE org_handle = $1 AND scope != 'identity_attributes' `,

--- a/internal/system/errors/error_codes.go
+++ b/internal/system/errors/error_codes.go
@@ -98,6 +98,16 @@ var (
 		Message: "Error while fetching applications.",
 	}
 
+	UPSERT_APPLICATION_FAILED = ErrorMessage{
+		Code:    errorPrefix + "15112",
+		Message: "Error while persisting application information.",
+	}
+
+	GET_APPLICATION_FAILED = ErrorMessage{
+		Code:    errorPrefix + "15113",
+		Message: "Error while resolving application information.",
+	}
+
 	ADD_UNIFICATION_RULE = ErrorMessage{
 		Code:    errorPrefix + "15201",
 		Message: "Error while adding unification rules.",

--- a/test/integration/application_store_test.go
+++ b/test/integration/application_store_test.go
@@ -58,7 +58,9 @@ func Test_ApplicationStore(t *testing.T) {
 		require.Equal(t, "", got)
 
 		// Service wrapper also returns empty on miss without surfacing an error.
-		require.Equal(t, "", appService.ResolveAppIdentifierByClientID(org, "unknown-client"))
+		resolved, err := appService.ResolveAppIdentifierByClientID(org, "unknown-client")
+		require.NoError(t, err)
+		require.Equal(t, "", resolved)
 	})
 
 	t.Run("Org_Scoped", func(t *testing.T) {

--- a/test/integration/application_store_test.go
+++ b/test/integration/application_store_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	appModel "github.com/wso2/identity-customer-data-service/internal/application/model"
+	appProvider "github.com/wso2/identity-customer-data-service/internal/application/provider"
+	appStore "github.com/wso2/identity-customer-data-service/internal/application/store"
+)
+
+func Test_ApplicationStore(t *testing.T) {
+
+	org := fmt.Sprintf("carbon.super-app-%d", time.Now().UnixNano())
+	otherOrg := fmt.Sprintf("other-app-%d", time.Now().UnixNano())
+	appService := appProvider.NewApplicationProvider().GetApplicationService()
+
+	appUUID := "40497337-e8bf-4d92-9545-711894ab2af3"
+	clientID := "PjR8xK2qClientId"
+
+	t.Run("Upsert_And_Resolve", func(t *testing.T) {
+		err := appStore.UpsertApplication(appModel.Application{
+			AppID:     appUUID,
+			OrgHandle: org,
+			ClientID:  clientID,
+		})
+		require.NoError(t, err)
+
+		got, err := appStore.GetAppIdentifierByClientID(org, clientID)
+		require.NoError(t, err)
+		require.Equal(t, appUUID, got)
+	})
+
+	t.Run("Resolve_Miss_Returns_Empty", func(t *testing.T) {
+		got, err := appStore.GetAppIdentifierByClientID(org, "unknown-client")
+		require.NoError(t, err)
+		require.Equal(t, "", got)
+
+		// Service wrapper also returns empty on miss without surfacing an error.
+		require.Equal(t, "", appService.ResolveAppIdentifierByClientID(org, "unknown-client"))
+	})
+
+	t.Run("Org_Scoped", func(t *testing.T) {
+		otherUUID := "aaaa1111-e8bf-4d92-9545-bbbbbbbbbbbb"
+		err := appStore.UpsertApplication(appModel.Application{
+			AppID:     otherUUID,
+			OrgHandle: otherOrg,
+			ClientID:  clientID, // same clientId, different org
+		})
+		require.NoError(t, err)
+
+		gotOrg, err := appStore.GetAppIdentifierByClientID(org, clientID)
+		require.NoError(t, err)
+		require.Equal(t, appUUID, gotOrg)
+
+		gotOther, err := appStore.GetAppIdentifierByClientID(otherOrg, clientID)
+		require.NoError(t, err)
+		require.Equal(t, otherUUID, gotOther)
+	})
+
+	t.Run("ClientId_Rotation_Updates_Mapping", func(t *testing.T) {
+		newClientID := "RotatedClientId"
+		err := appStore.UpsertApplication(appModel.Application{
+			AppID:     appUUID, // same app
+			OrgHandle: org,
+			ClientID:  newClientID, // rotated clientId
+		})
+		require.NoError(t, err)
+
+		// New clientId resolves to the app.
+		got, err := appStore.GetAppIdentifierByClientID(org, newClientID)
+		require.NoError(t, err)
+		require.Equal(t, appUUID, got)
+
+		// Old clientId no longer resolves (single row per app was updated in place).
+		old, err := appStore.GetAppIdentifierByClientID(org, clientID)
+		require.NoError(t, err)
+		require.Equal(t, "", old)
+	})
+
+	t.Run("Saml_Apps_Stored_With_Null_ClientID", func(t *testing.T) {
+		samlA := "saml-1111-e8bf-4d92-9545-cccccccccccc"
+		samlB := "saml-2222-e8bf-4d92-9545-dddddddddddd"
+
+		// SAML-only apps have no clientId; two of them in the same org must both persist without colliding.
+		require.NoError(t, appStore.UpsertApplication(appModel.Application{AppID: samlA, OrgHandle: org}))
+		require.NoError(t, appStore.UpsertApplication(appModel.Application{AppID: samlB, OrgHandle: org}))
+	})
+}

--- a/test/setup/schema.sql
+++ b/test/setup/schema.sql
@@ -82,6 +82,16 @@ CREATE TABLE application_data
     UNIQUE (profile_id, app_id)
 );
 
+CREATE TABLE applications
+(
+    app_id         VARCHAR(255) PRIMARY KEY,
+    org_handle     VARCHAR(255) NOT NULL,
+    client_id      VARCHAR(255),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (org_handle, client_id)
+);
+
 CREATE TABLE consent_categories
 (
     id                  SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Purpose
Introduce an `applications` table mapping the CDS application identifier (currently the IS application UUID) to its inbound authentication key (OAuth clientId). App-scoped profile schema attributes, application data, and consent attributes are now keyed by the app UUID instead of the clientId.

- New `internal/application` module (model/store/service/provider) with the applications mapping and clientId -> app_identifier resolution.
- `applications` table DDL (dbscripts + test schema) and query templates.
- IdentityClient.GetClientIDByAppID validates the app in IS and resolves its OIDC inbound clientId (404-tolerant for SAML-only apps).
- Schema-attribute validation now registers the clientId -> app mapping.
- Profile GET resolves the caller's OAuth clientId to the app_identifier before filtering application data (system-app check stays clientId-based).
- One-off migration tool (cmd/migrate-app-ids) to re-key existing data.
- API spec + docs updated; applications store integration test.